### PR TITLE
Updates to SCH message table approach. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,14 @@ project(CFS_SCH C)
 include_directories(fsw/public_inc)
 include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
+include_directories(fsw/src)
 
 aux_source_directory(fsw/src APP_SRC_FILES)
 
 # Create the app module
 add_cfe_app(sch ${APP_SRC_FILES})
+
+# Create the app tables if the parent build has the add_cfe_tables command
+if (COMMAND add_cfe_tables)
+  add_cfe_tables(sch fsw/tables/sch_def_schtbl.c fsw/tables/sch_def_msgtbl.c)
+endif(COMMAND add_cfe_tables)

--- a/fsw/platform_inc/sch_msgids.h
+++ b/fsw/platform_inc/sch_msgids.h
@@ -25,7 +25,7 @@
 ***************************/
 #define SCH_CMD_MID                    0x1895 /**< \brief SCH Ground Commands Message ID */
 #define SCH_SEND_HK_MID                0x1896 /**< \brief SCH Send Housekeeping Message ID */
-#define SCH_UNUSED_MID                 0x1897 /**< \brief SCH MDT Unused Message Message ID */
+#define SCH_UNUSED_MID                 (CFE_SB_HIGHEST_VALID_MSGID+1) /**< \brief SCH MDT Unused Message Message ID */
 /*
 #define SCH_SPARE1                     0x1898
 #define SCH_SPARE2                     0x1899

--- a/fsw/platform_inc/sch_platform_cfg.h
+++ b/fsw/platform_inc/sch_platform_cfg.h
@@ -110,7 +110,7 @@
 **       Must be at least large enough to hold the smallest possible message header 
 * **     (see #CFE_SB_TLM_HDR_SIZE and #CFE_SB_CMD_HDR_SIZE)
 */
-#define SCH_MAX_MSG_WORDS      64   /* max message length (in words) */
+#define SCH_MAX_MSG_WORDS      62   /* max message length (in words) */
 
 
 /*

--- a/fsw/src/sch_tbldefs.h
+++ b/fsw/src/sch_tbldefs.h
@@ -53,7 +53,11 @@ typedef struct
 */
 typedef struct
 {
-    uint16   MessageBuffer[SCH_MAX_MSG_WORDS]; /**< \brief Packed Messages */
+
+   CFE_SB_MsgId_t mid;                       /**< \brief MID to send */
+   uint16    cmdCode;                         /**< \brief Specifies the command code if relevant. */
+   uint16   payloadLength;                   /**< \brief Message length of any user payload. */
+   uint16   MessageBuffer[SCH_MAX_MSG_WORDS]; /**< \brief User payload content byte-stream. */
 
 } SCH_MessageEntry_t;
 

--- a/fsw/tables/sch_def_msgtbl.c
+++ b/fsw/tables/sch_def_msgtbl.c
@@ -76,7 +76,7 @@
 **  Entry 0 -- reserved (DO NOT USE)
 **  
 **  Several Entries in this default table provide example messages for a default
-**  system. These messages can be uncommented, and the CFE_MAKE_BIG16(SCH_UNUSED_MID) entry just
+**  system. These messages can be uncommented, and the SCH_UNUSED_MID entry just
 **  below them can be deleted to enable them.
 */
 
@@ -89,307 +89,307 @@ SCH_MessageEntry_t SCH_DefaultMessageTable[SCH_MAX_MESSAGES] =
   **  DO NOT USE -- entry #0 reserved for "unused" command ID - DO NOT USE
   */
     /* command ID #0 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
 
   /*
   **  cFE housekeeping request messages
   */
     /* command ID #1 - Executive Services HK Request   */
-  { { CFE_MAKE_BIG16(CFE_ES_SEND_HK_MID),   CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } },
+  { CFE_ES_SEND_HK_MID },
     /* command ID #2 - Event Services HK Request     */
-  { { CFE_MAKE_BIG16(CFE_EVS_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } },
+  { CFE_EVS_SEND_HK_MID },
     /* command ID #3 - Software Bus HK Request       */
-  { { CFE_MAKE_BIG16(CFE_SB_SEND_HK_MID),   CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } },
+  { CFE_SB_SEND_HK_MID },
     /* command ID #4 - Time Services HK Request      */
-  { { CFE_MAKE_BIG16(CFE_TIME_SEND_HK_MID), CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } },
+  { CFE_TIME_SEND_HK_MID },
     /* command ID #5 - Table Services HK Request     */
-  { { CFE_MAKE_BIG16(CFE_TBL_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } },
+  { CFE_TBL_SEND_HK_MID },
 
   /*
   **  CFS housekeeping request messages
   */
     /* command ID #6 - Checksum HK Request           */
-/*{ { CFE_MAKE_BIG16(CS_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ CS_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #7 - Data Store HK Request         */
-/*{ { CFE_MAKE_BIG16(DS_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ DS_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #8 - File Manager HK Request       */
-/*{ { CFE_MAKE_BIG16(FM_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ FM_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #9 - Housekeeping HK Request       */
-/*{ { CFE_MAKE_BIG16(HK_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ HK_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
 
     /* command ID #10 - Health & Safety HK Request   */
-/*{ { CFE_MAKE_BIG16(HS_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ HS_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #11 - Limit Checker HK Request     */
-/*{ { CFE_MAKE_BIG16(LC_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ LC_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #12 - Memory Dwell HK Request      */
-/*{ { CFE_MAKE_BIG16(MD_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ MD_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #13 - Memory Manager HK Request    */
-/*{ { CFE_MAKE_BIG16(MM_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ MM_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #14 - Stored Command HK Request    */
-/*{ { CFE_MAKE_BIG16(SC_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
-    /* command ID #15 - Scheduler HK Request         */
-  { { CFE_MAKE_BIG16(SCH_SEND_HK_MID), CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } },
+/*{ SC_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
+    /* command ID #15 */
+  { SCH_SEND_HK_MID },
 
   /*
   **  CFS routine messages
   */
     /* command ID #16 - HK Send Combined Housekeeping Msg #1 */
-/*{ { CFE_MAKE_BIG16(HK_SEND_COMBINED_PKT_MID), CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0003), 0x0000, HK_COMBINED_PKT1_MID } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ HK_SEND_COMBINED_PKT_MID, 0, 2, {HK_COMBINED_PKT1_MID} }, */
+  { SCH_UNUSED_MID },
     /* command ID #17 - HK Send Combined Housekeeping Msg #2 */
-/*{ { CFE_MAKE_BIG16(HK_SEND_COMBINED_PKT_MID), CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0003), 0x0000, HK_COMBINED_PKT2_MID } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ HK_SEND_COMBINED_PKT_MID, 0, 2, {HK_COMBINED_PKT2_MID} }, */
+  { SCH_UNUSED_MID },
     /* command ID #18 - HK Send Combined Housekeeping Msg #3 */
-/*{ { CFE_MAKE_BIG16(HK_SEND_COMBINED_PKT_MID), CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0003), 0x0000, HK_COMBINED_PKT3_MID } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ HK_SEND_COMBINED_PKT_MID, 0, 2, {HK_COMBINED_PKT3_MID} }, */
+  { SCH_UNUSED_MID },
     /* command ID #19 - HK Send Combined Housekeeping Msg #4 */
-/*{ { CFE_MAKE_BIG16(HK_SEND_COMBINED_PKT_MID), CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0003), 0x0000, HK_COMBINED_PKT4_MID } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ HK_SEND_COMBINED_PKT_MID, 0, 2, {HK_COMBINED_PKT4_MID} }, */
+  { SCH_UNUSED_MID },
     /* command ID #20 - CS Background Cycle               */
-/*{ { CFE_MAKE_BIG16(CS_BACKGROUND_CYCLE_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ CS_BACKGROUND_CYCLE_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #21 - SC 1 Hz Wakeup                    */
-/*{ { CFE_MAKE_BIG16(SC_1HZ_WAKEUP_MID),        CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ SC_1HZ_WAKEUP_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #22 - LC Sample Action Points           */
-/*{ { CFE_MAKE_BIG16(LC_SAMPLE_AP_MID),         CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0005), 0x0000, LC_ALL_ACTIONPOINTS, 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ LC_SAMPLE_AP_MID, 0, 4, {LC_ALL_ACTIONPOINTS} }, */
+  { SCH_UNUSED_MID },
     /* command ID #23 - DS 1 HZ Wakeup                    */
-/*{ { CFE_MAKE_BIG16(DS_1HZ_WAKEUP_MID),        CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ DS_1HZ_WAKEUP_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #24 - MD Wakeup                         */
-/*{ { CFE_MAKE_BIG16(MD_WAKEUP_MID),            CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ MD_WAKEUP_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #25 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #26 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #27 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #28 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #29 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
 
   /*
   **  Mission Defined Messages
   */
     /* command ID #30 - Command Ingest HK Request Example */
-/*{ { CFE_MAKE_BIG16(CI_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ CI_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #31 - Telemetry Output HK Request Example */
-/*{ { CFE_MAKE_BIG16(TO_SEND_HK_MID),  CFE_MAKE_BIG16(0xC000), CFE_MAKE_BIG16(0x0001), 0x0000 } }, */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+/*{ TO_SEND_HK_MID }, */
+  { SCH_UNUSED_MID },
     /* command ID #32 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #33 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #34 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },  
+  { SCH_UNUSED_MID },  
     /* command ID #35 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #36 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #37 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #38 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #39 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
   
     /* command ID #40 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #41 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #42 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #43 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #44 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },  
+  { SCH_UNUSED_MID },  
     /* command ID #45 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #46 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #47 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #48 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #49 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
 
     /* command ID #50 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #51 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #52 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #53 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #54 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },  
+  { SCH_UNUSED_MID },  
     /* command ID #55 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #56 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #57 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #58 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #59 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
 
     /* command ID #60 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #61 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #62 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #63 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #64 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },  
+  { SCH_UNUSED_MID },  
     /* command ID #65 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #66 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #67 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #68 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #69 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
 
     /* command ID #70 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #71 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #72 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #73 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #74 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #75 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #76 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #77 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #78 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #79 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
   
     /* command ID #80 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #81 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #82 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #83 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #84 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #85 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #86 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #87 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #88 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #89 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
   
     /* command ID #90 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #91 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #92 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #93 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #94 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #95 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #96 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #97 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #98 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #99 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
   
     /* command ID #100 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #101 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #102 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #103 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #104 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #105 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #106 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #107 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #108 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #109 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
   
     /* command ID #110 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #111 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #112 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #113 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #114 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #115 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #116 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #117 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #118 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #119 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
   
     /* command ID #120 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #121 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #122 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #123 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #124 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #125 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #126 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } },
+  { SCH_UNUSED_MID },
     /* command ID #127 */
-  { { CFE_MAKE_BIG16(SCH_UNUSED_MID) } }
+  { SCH_UNUSED_MID }
 
 };
 


### PR DESCRIPTION
Abstracted CCSDS header info from the generic message component. Allows CCSDS v1 and v2 compatibility. Also, allows changes to CCSDS v2 bit configurations without a table source file change.