### PR TITLE
Update the SCH codebase to a more recent cFS revision (March 2023)

### DIFF
--- a/fsw/platform_inc/sch_platform_cfg.h
+++ b/fsw/platform_inc/sch_platform_cfg.h
@@ -94,10 +94,11 @@
 **       Dictates the maximum message ID that can be used in the Message Definition Table.
 **
 **  \par Limits
-**       Must be less than or equal to #CFE_SB_HIGHEST_VALID_MSGID and greater than SCH_MDT_MIN_MSG_ID
+**       Must be less than or equal to #CFE_PLATFORM_SB_HIGHEST_VALID_MSGID and greater than
+*SCH_MDT_MIN_MSG_ID
 */
-#define SCH_MDT_MAX_MSG_ID    CFE_SB_HIGHEST_VALID_MSGID
 
+#define SCH_MDT_MAX_MSG_ID CFE_PLATFORM_SB_HIGHEST_VALID_MSGID
 
 /**
 **  \schcfg Maximum Length, in Words, of a Message 

--- a/fsw/public_inc/sch_api.h
+++ b/fsw/public_inc/sch_api.h
@@ -82,7 +82,7 @@ void SCH_DisableProcessing(void);
 **
 **
 ******************************************************************************/
-boolean SCH_GetProcessingState(void);
+bool SCH_GetProcessingState(void);
 
 #endif /* _sch_api_ */
 

--- a/fsw/src/sch_apipriv.h
+++ b/fsw/src/sch_apipriv.h
@@ -102,7 +102,7 @@ void SCH_DisableProcessing(void);
 **       None
 **       
 *************************************************************************/
-boolean SCH_GetProcessingState(void);
+bool SCH_GetProcessingState(void);
 
 #endif /* _sch_apipriv_ */
 

--- a/fsw/src/sch_app.h
+++ b/fsw/src/sch_app.h
@@ -137,7 +137,7 @@ typedef struct
     /*
     ** Operational data 
     */
-    CFE_SB_MsgPtr_t       MsgPtr;                         /**< \brief Ptr to most recently received cmd message */
+    CFE_SB_Buffer_t       *MsgPtr;                        /**< \brief Ptr to most recently received cmd message */
     CFE_SB_PipeId_t       CmdPipe;                        /**< \brief Pipe ID for SCH Command Pipe */
     
     SCH_MessageEntry_t   *MessageTable;                   /**< \brief Ptr to Message Table contents */

--- a/fsw/src/sch_cmds.h
+++ b/fsw/src/sch_cmds.h
@@ -76,18 +76,18 @@
 **  \sa #CFE_SB_RcvMsg
 **
 *************************************************************************/
-int32 SCH_AppPipe(CFE_SB_MsgPtr_t MessagePtr);
+int32 SCH_AppPipe(CFE_SB_Buffer_t *MessagePtr);
 
 /************************************************************************/
 /** \brief Manages Scheduler's Schedule and Message Definition Tables
-**  
+**
 **  \par Description
 **       This function manages the contents of the Schedule and Message
 **       Definition Tables.
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
+**
 **  \returns
 **  \retcode #CFE_SUCCESS  \retdesc \copydoc CFE_SUCCESS \endcode
 **  \retstmt Return codes from #CFE_EVS_Register         \endcode
@@ -100,16 +100,16 @@ int32 SCH_AcquirePointers(void);
 
 /************************************************************************/
 /** \brief Process housekeeping request
-**  
+**
 **  \par Description
 **       Processes an on-board housekeeping request message.
 **
 **  \par Assumptions, External Events, and Notes:
 **       This command does not affect the command execution counter
-**       
-**  \param [in]   MessagePtr   A #CFE_SB_MsgPtr_t pointer that
-**                             references the software bus message 
-**       
+**
+**  \param [in]   MessagePtr   A #CFE_SB_MsgId_t pointer that
+**                             references the software bus message
+**
 **  \returns
 **  \retcode #CFE_SUCCESS  \retdesc \copydoc CFE_SUCCESS \endcode
 **  \retstmt Return codes from #CFE_EVS_Register         \endcode
@@ -118,31 +118,31 @@ int32 SCH_AcquirePointers(void);
 **  \endreturns
 **
 *************************************************************************/
-int32 SCH_HousekeepingCmd(CFE_SB_MsgPtr_t MessagePtr);
+int32 SCH_HousekeepingCmd(CFE_MSG_Message_t *MessagePtr);
 
 /*
 ** Application command handlers
 */
 /************************************************************************/
 /** \brief Process noop command
-**  
+**
 **  \par Description
 **       Processes a noop ground command.
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
-**  \param [in]   MessagePtr   A #CFE_SB_MsgPtr_t pointer that
-**                             references the software bus message 
+**
+**  \param [in]   MessagePtr   A #CFE_SB_MsgId_t pointer that
+**                             references the software bus message
 **
 **  \sa #SCH_NOOP_CC
 **
 *************************************************************************/
-void SCH_NoopCmd(CFE_SB_MsgPtr_t MessagePtr);
+void SCH_NoopCmd(CFE_MSG_Message_t *MessagePtr);
 
 /************************************************************************/
 /** \brief Process reset counters command
-**  
+**
 **  \par Description
 **       Processes a reset counters ground command which will reset
 **       the Scheduler commmand error, command execution and performance
@@ -150,90 +150,90 @@ void SCH_NoopCmd(CFE_SB_MsgPtr_t MessagePtr);
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
-**  \param [in]   MessagePtr   A #CFE_SB_MsgPtr_t pointer that
-**                             references the software bus message 
+**
+**  \param [in]   MessagePtr   A #CFE_SB_MsgId_t pointer that
+**                             references the software bus message
 **
 **  \sa #SCH_RESET_CC
 **
 *************************************************************************/
-void SCH_ResetCmd(CFE_SB_MsgPtr_t MessagePtr);
+void SCH_ResetCmd(CFE_MSG_Message_t *MessagePtr);
 
 /************************************************************************/
 /** \brief Enable a Single Activity Command
-**  
+**
 **  \par Description
-**       Command to Enable a specific activity in the Schedule 
+**       Command to Enable a specific activity in the Schedule
 **       Definition Table.
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
-**  \param [in]   MessagePtr     A #CFE_SB_MsgPtr_t pointer that
-**                               references the software bus message 
-**       
+**
+**  \param [in]   MessagePtr     A #CFE_SB_MsgId_t pointer that
+**                               references the software bus message
+**
 **  \sa #SCH_ENABLE_CC, #SCH_DISABLE_CC, #SCH_ENABLE_GROUP_CC, #SCH_DISABLE_GROUP_CC
 **
 *************************************************************************/
-void SCH_EnableCmd(CFE_SB_MsgPtr_t MessagePtr);
+void SCH_EnableCmd(CFE_MSG_Message_t *MessagePtr);
 
 /************************************************************************/
 /** \brief Disable a Single Activity Command
-**  
+**
 **  \par Description
-**       Command to Disable a specific activity in the Schedule 
+**       Command to Disable a specific activity in the Schedule
 **       Definition Table.
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
-**  \param [in]   MessagePtr     A #CFE_SB_MsgPtr_t pointer that
-**                               references the software bus message 
-**       
+**
+**  \param [in]   MessagePtr     A #CFE_SB_MsgId_t pointer that
+**                               references the software bus message
+**
 **  \sa #SCH_ENABLE_CC, #SCH_DISABLE_CC, #SCH_ENABLE_GROUP_CC, #SCH_DISABLE_GROUP_CC
 **
 *************************************************************************/
-void SCH_DisableCmd(CFE_SB_MsgPtr_t MessagePtr);
+void SCH_DisableCmd(CFE_MSG_Message_t *MessagePtr);
 
 /************************************************************************/
 /** \brief Enable a Group and/or Multi-Group(s) Command
-**  
+**
 **  \par Description
 **       Command to Enable a single Group and/or one or more Multi-Groups
 **       of activities.
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
-**  \param [in]   MessagePtr     A #CFE_SB_MsgPtr_t pointer that
-**                               references the software bus message 
-**       
+**
+**  \param [in]   MessagePtr     A #CFE_SB_MsgId_t pointer that
+**                               references the software bus message
+**
 **  \sa #SCH_ENABLE_CC, #SCH_DISABLE_CC, #SCH_ENABLE_GROUP_CC, #SCH_DISABLE_GROUP_CC
 **
 *************************************************************************/
-void SCH_EnableGroupCmd(CFE_SB_MsgPtr_t MessagePtr);
+void SCH_EnableGroupCmd(CFE_MSG_Message_t *MessagePtr);
 
 /************************************************************************/
 /** \brief Disable a Group and/or Multi-Group(s) Command
-**  
+**
 **  \par Description
 **       Command to Disable a single Group and/or one or more Multi-Groups
 **       of activities.
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
-**  \param [in]   MessagePtr     A #CFE_SB_MsgPtr_t pointer that
-**                               references the software bus message 
-**       
+**
+**  \param [in]   MessagePtr     A #CFE_SB_MsgId_t pointer that
+**                               references the software bus message
+**
 **  \sa #SCH_ENABLE_CC, #SCH_DISABLE_CC, #SCH_ENABLE_GROUP_CC, #SCH_DISABLE_GROUP_CC
 **
 *************************************************************************/
-void SCH_DisableGroupCmd(CFE_SB_MsgPtr_t MessagePtr);
+void SCH_DisableGroupCmd(CFE_MSG_Message_t *MessagePtr);
 
 /************************************************************************/
 /** \brief Enables Major Frame Synchronization
-**  
+**
 **  \par Description
 **       Command to enable synchronization of Schedule Definition Table to
 **       the Major Frame Sync signal.  The synchronization can become
@@ -241,33 +241,33 @@ void SCH_DisableGroupCmd(CFE_SB_MsgPtr_t MessagePtr);
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
-**  \param [in]   MessagePtr     A #CFE_SB_MsgPtr_t pointer that
-**                               references the software bus message 
-**       
+**
+**  \param [in]   MessagePtr     A #CFE_SB_MsgId_t pointer that
+**                               references the software bus message
+**
 **  \sa #SCH_ENABLE_CC, #SCH_DISABLE_CC, #SCH_ENABLE_GROUP_CC, #SCH_DISABLE_GROUP_CC
 **
 *************************************************************************/
-void SCH_EnableSyncCmd(CFE_SB_MsgPtr_t MessagePtr);
+void SCH_EnableSyncCmd(CFE_MSG_Message_t *MessagePtr);
 
 /************************************************************************/
 /** \brief Creates and sends diagnostic message packet
-**  
+**
 **  \par Description
 **       Command to send the Scheduler diagnostic message.
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
-**  \param [in]   MessagePtr     A #CFE_SB_MsgPtr_t pointer that
-**                               references the software bus message 
-**       
+**
+**  \param [in]   MessagePtr     A #CFE_SB_MsgId_t pointer that
+**                               references the software bus message
+**
 *************************************************************************/
-void SCH_SendDiagTlmCmd(CFE_SB_MsgPtr_t MessagePtr);
+void SCH_SendDiagTlmCmd(CFE_MSG_Message_t *MessagePtr);
 
 /************************************************************************/
 /** \brief Updates appropriate command counters following command execution
-**  
+**
 **  \par Description
 **       This function updates the ground or on-board command counter or
 **       command error counter depending upon the success of the command
@@ -275,17 +275,17 @@ void SCH_SendDiagTlmCmd(CFE_SB_MsgPtr_t MessagePtr);
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
+**
 **  \param [in]   GoodCommand    Indicates the command was successfully
 **                               performed (=TRUE) or contained an error
-**                               (=FALSE). 
-**       
+**                               (=FALSE).
+**
 *************************************************************************/
-void SCH_PostCommandResult(boolean GoodCommand);
+void SCH_PostCommandResult(bool GoodCommand);
 
 /************************************************************************/
 /** \brief Verifies the length of the specified message
-**  
+**
 **  \par Description
 **       This function determines whether the specified message is of the
 **       specified expected length.  If not, an event message is generated
@@ -295,14 +295,14 @@ void SCH_PostCommandResult(boolean GoodCommand);
 **
 **  \par Assumptions, External Events, and Notes:
 **       None
-**       
-**       
-**  \param [in]   MessagePtr     A #CFE_SB_MsgPtr_t pointer that
-**                               references the software bus message 
-**       
+**
+**
+**  \param [in]   MessagePtr     A #CFE_SB_MsgId_t pointer that
+**                               references the software bus message
+**
 **  \param [in]   ExpectedLength The size, in bytes, that the specified
-**                               message should be equal to. 
-**       
+**                               message should be equal to.
+**
 **  \returns
 **  \retcode #CFE_SUCCESS  \retdesc \copydoc CFE_SUCCESS \endcode
 **  \retstmt Return codes from #CFE_EVS_Register         \endcode
@@ -311,7 +311,7 @@ void SCH_PostCommandResult(boolean GoodCommand);
 **  \endreturns
 **
 *************************************************************************/
-int32 SCH_VerifyCmdLength (CFE_SB_MsgPtr_t MessagePtr, uint32 ExpectedLength);
+int32 SCH_VerifyCmdLength(CFE_MSG_Message_t *MessagePtr, uint32 ExpectedLength);
 
 #endif /* _sch_cmds_ */
 

--- a/fsw/src/sch_custom.c
+++ b/fsw/src/sch_custom.c
@@ -30,9 +30,6 @@
 #include "sch_app.h"
 #include "sch_custom.h"
 
-#include "cfe_time_msg.h"
-
-
 /*************************************************************************
 **
 ** Macro definitions
@@ -238,8 +235,8 @@ void SCH_MajorFrameCallback(void)
     ** If cFE TIME is in FLYWHEEL mode, then ignore all synchronization signals
     */
     StateFlags = CFE_TIME_GetClockInfo();
-    
-    if ((StateFlags & CFE_TIME_FLAG_FLYING) == 0)
+
+    if ((StateFlags & CFE_TIME_FlagBit_FLYING) == 0)
     {
         /*
         ** Determine whether the major frame is noisy or not
@@ -265,7 +262,7 @@ void SCH_MajorFrameCallback(void)
             ** of noisy major frames.  Also, indicate in telemetry that this particular
             ** Major Frame signal is considered noisy.
             */
-            SCH_AppData.UnexpectedMajorFrame = TRUE;
+            SCH_AppData.UnexpectedMajorFrame = true;
             SCH_AppData.UnexpectedMajorFrameCount++;
 
             /*
@@ -281,20 +278,20 @@ void SCH_MajorFrameCallback(void)
                 */
                 if (SCH_AppData.ConsecutiveNoisyFrameCounter >= SCH_MAX_NOISY_MAJORF)
                 {
-                    SCH_AppData.IgnoreMajorFrame = TRUE;
+                    SCH_AppData.IgnoreMajorFrame = true;
                 }
             }
         }
         else /* Major Frame occurred when expected */
         {
-            SCH_AppData.UnexpectedMajorFrame = FALSE;
+            SCH_AppData.UnexpectedMajorFrame         = false;
             SCH_AppData.ConsecutiveNoisyFrameCounter = 0;
         }
         
         /*
         ** Ignore this callback if SCH has detected a noisy Major Frame Synch signal
         */
-        if (SCH_AppData.IgnoreMajorFrame == FALSE)
+        if (SCH_AppData.IgnoreMajorFrame == false)
         {
             /*
             ** Stop Minor Frame Timer (which should be waiting for an unusually long

--- a/fsw/src/sch_msg.h
+++ b/fsw/src/sch_msg.h
@@ -54,8 +54,7 @@
 */
 typedef struct
 {
-    uint8             CmdHeader[CFE_SB_CMD_HDR_SIZE];  /**< \brief cFE Software Bus Command Message Header */
-
+    CFE_MSG_CommandHeader_t CmdHeader;
 } SCH_NoArgsCmd_t;
 
 /*
@@ -68,13 +67,12 @@ typedef struct
 */
 typedef struct
 {
-    uint8    CmdHeader[CFE_SB_CMD_HDR_SIZE];          /**< \brief cFE Software Bus Command Message Header */
+    CFE_MSG_CommandHeader_t CmdHeader;
 
-    uint16   SlotNumber;                              /**< \brief Slot Number of Activity whose state is to change */
-                                                      /**< \details Valid Range is zero to (#SCH_TOTAL_SLOTS - 1) */
-    uint16   EntryNumber;                             /**< \brief Entry Number of Activity whose state is to change
-                                                           \details Valid Range is zero to (#SCH_ENTRIES_PER_SLOT - 1) */
-
+    uint16 SlotNumber;  /**< \brief Slot Number of Activity whose state is to change */
+                        /**< \details Valid Range is zero to (#SCH_TOTAL_SLOTS - 1) */
+    uint16 EntryNumber; /**< \brief Entry Number of Activity whose state is to change
+                             \details Valid Range is zero to (#SCH_ENTRIES_PER_SLOT - 1) */
 } SCH_EntryCmd_t;
 
 /*
@@ -87,7 +85,7 @@ typedef struct
 */
 typedef struct
 {
-    uint8    CmdHeader[CFE_SB_CMD_HDR_SIZE];          /**< \brief cFE Software Bus Command Message Header */
+    CFE_MSG_CommandHeader_t CmdHeader;
 
     uint32   GroupData;                               /**< \brief Group and Multi-Group Identifiers
                                                            \details Most Significant Byte contains a Group ID of 1 to 255,
@@ -107,7 +105,7 @@ typedef struct
 
 typedef struct
 {
-    uint8    TlmHeader[CFE_SB_TLM_HDR_SIZE];          /**< \brief cFE Software Bus Telemetry Message Header */
+    CFE_MSG_TelemetryHeader_t TlmHeader;
 
     /*
     ** Command execution counters (ground commands)
@@ -229,7 +227,7 @@ typedef struct
 
 typedef struct
 {
-    uint8           TlmHeader[CFE_SB_TLM_HDR_SIZE];   /**< \brief cFE Software Bus Telemetry Message Header */
+    CFE_MSG_TelemetryHeader_t TlmHeader;              /**< \brief cFE Software Bus Telemetry Message Header */
 
     uint16          EntryStates[SCH_NUM_STATUS_BYTES_REQD/2]; 
                                                       /**< \schtlmmnemonic \SCH_ENTRYSTATES


### PR DESCRIPTION
Hello,

We learned that the SCH codebase had not been updated since June 2019, so we updated it to have it at least compile with our customized cFS build system.

We hope that this work will help someone like us to get to a working SCH faster.

If there was any interest in integrating this work, we would be happy to resolve any issues with this patch. Before doing any integration, we would highly recommend setting up Clang Format for SCH, using the `.clang-format` from the parent cFS repository. With the formatting in place, it would be much easier to work with the needed diffs.

This contribution is made on behalf of Reflex Aerospace GmbH (Berlin) where I am employed as a software engineer.

---

This changeset contains 90%+ fixes that are needed to have this SCH working against the more recent cFS setup as of March 2023.

The cFS revision that this is compiled against: 192f2ea3061bfe722b8ed1d72b7adecbf36d4f6e

https://github.com/nasa/cFS/commit/192f2ea3061bfe722b8ed1d72b7adecbf36d4f6e

Known issues:

- The changeset contains minor formatting issues but I am deciding to ignore them because the SCH itself needs to be Clang Formatted and I didn't find an existing .clang-format in the repository.
- This changeset does not touch anything related to setting up the table files in the CMake build system. There are other patches that are attempting to fix those issues: https://github.com/nasa/SCH/pull/6/files
- We are still reworking the SCH codebase to fit our needs, so it may be that a few lines were missed and they will not compile.